### PR TITLE
ScriptEngineTest - File name mismatch with class name

### DIFF
--- a/src/classes/ScriptEngineTest.cls
+++ b/src/classes/ScriptEngineTest.cls
@@ -22,7 +22,7 @@
  * SOFTWARE.
  **/
 @IsTest
-private class ScriptEngine_Test {
+private class ScriptEngineTest {
     static ScriptEngine se = ScriptEngine.getInstance();
     @IsTest
     private static void objectTest() {


### PR DESCRIPTION
Got this error when I compiled it.
`File name mismatch with class name: ScriptEngine_Test`